### PR TITLE
Improve TTS gradio UI

### DIFF
--- a/gradio_tts_app.py
+++ b/gradio_tts_app.py
@@ -4,6 +4,12 @@ import torch
 import gradio as gr
 from chatterbox.tts import ChatterboxTTS
 
+EXAMPLE_TEXTS = [
+    "Now let's make my mum's favourite. So three mars bars into the pan. Then we add the tuna and just stir for a bit, just let the chocolate and fish infuse. A sprinkle of olive oil and some tomato ketchup. Now smell that. Oh boy this is going to be incredible.",
+    "Ezreal and Jinx teamed up with Ahri, Yasuo, and Teemo to take down the enemy's Nexus in an epic late-game pentakill.",
+    "Hello there! I'm the open source Chatterbox TTS from Resemble AI."
+]
+
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -41,50 +47,59 @@ def generate(model, text, audio_prompt_path, exaggeration, temperature, seed_num
     return (model.sr, wav.squeeze(0).numpy())
 
 
-with gr.Blocks() as demo:
-    model_state = gr.State(None)  # Loaded once per session/user
+with gr.Blocks(title="Chatterbox TTS") as demo:
+    gr.Markdown("# Chatterbox TTS\nGenerate expressive speech with your own voice sample.")
+    model_state = gr.State(None)
 
-    with gr.Row():
-        with gr.Column():
-            text = gr.Textbox(
-                value="Now let's make my mum's favourite. So three mars bars into the pan. Then we add the tuna and just stir for a bit, just let the chocolate and fish infuse. A sprinkle of olive oil and some tomato ketchup. Now smell that. Oh boy this is going to be incredible.",
-                label="Text to synthesize (max chars 300)",
-                max_lines=5
-            )
-            ref_wav = gr.Audio(sources=["upload", "microphone"], type="filepath", label="Reference Audio File", value=None)
-            exaggeration = gr.Slider(0.25, 2, step=.05, label="Exaggeration (Neutral = 0.5, extreme values can be unstable)", value=.5)
-            cfg_weight = gr.Slider(0.0, 1, step=.05, label="CFG/Pace", value=0.5)
+    with gr.Tab("Synthesize"):
+        with gr.Row():
+            with gr.Column():
+                text = gr.Textbox(
+                    label="Text to synthesize",
+                    max_lines=5,
+                    placeholder="Enter text here...",
+                    value=EXAMPLE_TEXTS[0],
+                )
+                gr.Examples(EXAMPLE_TEXTS, inputs=text, label="Example prompts")
+                ref_wav = gr.Audio(sources=["upload", "microphone"], type="filepath", label="Reference Audio File", value=None)
+                exaggeration = gr.Slider(0.25, 2, step=.05, label="Exaggeration (Neutral = 0.5)", value=.5)
+                cfg_weight = gr.Slider(0.0, 1, step=.05, label="CFG/Pace", value=0.5)
 
-            with gr.Accordion("More options", open=False):
-                seed_num = gr.Number(value=0, label="Random seed (0 for random)")
-                temp = gr.Slider(0.05, 5, step=.05, label="temperature", value=.8)
-                min_p = gr.Slider(0.00, 1.00, step=0.01, label="min_p || Newer Sampler. Recommend 0.02 > 0.1. Handles Higher Temperatures better. 0.00 Disables", value=0.05)
-                top_p = gr.Slider(0.00, 1.00, step=0.01, label="top_p || Original Sampler. 1.0 Disables(recommended). Original 0.8", value=1.00)
-                repetition_penalty = gr.Slider(1.00, 2.00, step=0.1, label="repetition_penalty", value=1.2)
+                with gr.Accordion("Advanced", open=False):
+                    seed_num = gr.Number(value=0, label="Random seed (0 for random)")
+                    temp = gr.Slider(0.05, 5, step=.05, label="temperature", value=.8)
+                    min_p = gr.Slider(0.00, 1.00, step=0.01, label="min_p", value=0.05)
+                    top_p = gr.Slider(0.00, 1.00, step=0.01, label="top_p", value=1.00)
+                    repetition_penalty = gr.Slider(1.00, 2.00, step=0.1, label="repetition_penalty", value=1.2)
 
-            run_btn = gr.Button("Generate", variant="primary")
+                run_btn = gr.Button("Generate", variant="primary")
 
-        with gr.Column():
-            audio_output = gr.Audio(label="Output Audio")
+            with gr.Column():
+                audio_output = gr.Audio(label="Output Audio")
 
-    demo.load(fn=load_model, inputs=[], outputs=model_state)
+        demo.load(fn=load_model, inputs=[], outputs=model_state)
 
-    run_btn.click(
-        fn=generate,
-        inputs=[
-            model_state,
-            text,
-            ref_wav,
-            exaggeration,
-            temp,
-            seed_num,
-            cfg_weight,
-            min_p,
-            top_p,
-            repetition_penalty,
-        ],
-        outputs=audio_output,
-    )
+        run_btn.click(
+            fn=generate,
+            inputs=[
+                model_state,
+                text,
+                ref_wav,
+                exaggeration,
+                temp,
+                seed_num,
+                cfg_weight,
+                min_p,
+                top_p,
+                repetition_penalty,
+            ],
+            outputs=audio_output,
+        )
+
+    with gr.Tab("About"):
+        gr.Markdown(
+            "Chatterbox is an open source TTS model by [Resemble AI](https://resemble.ai)."
+        )
 
 if __name__ == "__main__":
     demo.queue(


### PR DESCRIPTION
## Summary
- enhance `gradio_tts_app.py` with examples and an About tab
- tidy layout for easier usage

## Testing
- `python -m py_compile gradio_tts_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68530eb943e88330b635cd6373b52f37