### PR TITLE
Add audio splicing and editing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,35 @@ ta.save("test-2.wav", wav, model.sr)
 ```
 See `example_tts.py` and `example_vc.py` for more examples.
 
+## Audio Editing Utilities
+
+Chatterbox now includes helper functions for basic waveform editing found in
+`chatterbox.audio_editing`. You can splice clips together, trim sections or
+apply a simple crossfade.
+
+```python
+from chatterbox.audio_editing import splice_audios, trim_audio
+import librosa
+
+wav1, _ = librosa.load("first.wav", sr=None)
+wav2, _ = librosa.load("second.wav", sr=None)
+joined = splice_audios([wav1, wav2])
+trimmed = trim_audio(joined, start_sec=0.5, end_sec=1.5, sr=model.sr)
+```
+
+## Sample Prompts
+
+To quickly experiment with Chatterbox, you can load the text prompts in
+`sample_prompts.json` located at the project root.
+
+```python
+import json
+with open("sample_prompts.json") as f:
+    sample_prompts = json.load(f)
+
+wav = model.generate(sample_prompts[0])
+```
+
 # Supported Lanugage
 Currenlty only English.
 

--- a/sample_prompts.json
+++ b/sample_prompts.json
@@ -1,0 +1,5 @@
+[
+  "Now let's make my mum's favourite. So three mars bars into the pan. Then we add the tuna and just stir for a bit, just let the chocolate and fish infuse. A sprinkle of olive oil and some tomato ketchup. Now smell that. Oh boy this is going to be incredible.",
+  "Ezreal and Jinx teamed up with Ahri, Yasuo, and Teemo to take down the enemy's Nexus in an epic late-game pentakill.",
+  "Hello there! I'm the open source Chatterbox TTS from Resemble AI."
+]

--- a/src/chatterbox/__init__.py
+++ b/src/chatterbox/__init__.py
@@ -8,3 +8,10 @@ __version__ = version("chatterbox-tts")
 
 from .tts import ChatterboxTTS
 from .vc import ChatterboxVC
+from .audio_editing import (
+    splice_audios,
+    trim_audio,
+    insert_audio,
+    delete_segment,
+    crossfade,
+)

--- a/src/chatterbox/audio_editing.py
+++ b/src/chatterbox/audio_editing.py
@@ -1,0 +1,45 @@
+import numpy as np
+import librosa
+
+
+def splice_audios(audios):
+    """Concatenate a list of 1D audio arrays."""
+    if not audios:
+        raise ValueError("No audio segments provided")
+    return np.concatenate(audios)
+
+
+def trim_audio(audio, start_sec=0.0, end_sec=None, sr=22050):
+    """Trim a section from ``start_sec`` to ``end_sec`` (in seconds)."""
+    start = max(0, int(start_sec * sr))
+    end = len(audio) if end_sec is None else int(end_sec * sr)
+    if start >= end:
+        return np.array([], dtype=audio.dtype)
+    return audio[start:end]
+
+
+def insert_audio(base_audio, insert_audio, position_sec, sr=22050):
+    """Insert ``insert_audio`` into ``base_audio`` at ``position_sec`` seconds."""
+    pos = max(0, min(len(base_audio), int(position_sec * sr)))
+    return np.concatenate([base_audio[:pos], insert_audio, base_audio[pos:]])
+
+
+def delete_segment(audio, start_sec, end_sec, sr=22050):
+    """Remove the section between ``start_sec`` and ``end_sec`` seconds."""
+    start = max(0, int(start_sec * sr))
+    end = min(len(audio), int(end_sec * sr))
+    return np.concatenate([audio[:start], audio[end:]])
+
+
+def crossfade(audio1, audio2, duration_sec=0.01, sr=22050):
+    """Crossfade ``audio1`` into ``audio2`` over ``duration_sec`` seconds."""
+    n = int(duration_sec * sr)
+    if n <= 0:
+        return np.concatenate([audio1, audio2])
+    fade_out = np.linspace(1.0, 0.0, n)
+    fade_in = np.linspace(0.0, 1.0, n)
+    a1_end = audio1[-n:] * fade_out
+    a2_start = audio2[:n] * fade_in
+    mixed = a1_end + a2_start
+    return np.concatenate([audio1[:-n], mixed, audio2[n:]])
+

--- a/tests/test_audio_editing.py
+++ b/tests/test_audio_editing.py
@@ -1,0 +1,35 @@
+import numpy as np
+from chatterbox.audio_editing import (
+    splice_audios,
+    trim_audio,
+    insert_audio,
+    delete_segment,
+    crossfade,
+)
+
+
+def test_splice_and_trim():
+    a = np.ones(1000)
+    b = np.zeros(1000)
+    joined = splice_audios([a, b])
+    assert joined.size == 2000
+    trimmed = trim_audio(joined, start_sec=0, end_sec=0.01, sr=100000)
+    assert trimmed.size == 1000
+
+
+def test_insert_and_delete():
+    base = np.zeros(1000)
+    ins = np.ones(100)
+    inserted = insert_audio(base, ins, 0.5, sr=1000)
+    assert inserted[500:600].sum() == 100
+    deleted = delete_segment(inserted, 0.5, 0.6, sr=1000)
+    assert deleted.size == 1000
+
+
+def test_crossfade():
+    a1 = np.zeros(100)
+    a2 = np.ones(100)
+    out = crossfade(a1, a2, duration_sec=0.01, sr=10000)
+    expected = len(a1) + len(a2) - int(0.01 * 10000)
+    assert out.size == expected
+


### PR DESCRIPTION
## Summary
- implement `audio_editing` module with helper functions for trimming, splicing and more
- expose new helpers in the package init
- document audio editing utilities in README
- add unit tests
- include `sample_prompts.json` with usage example in README

## Testing
- `pip install -e .` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6853144f8c00833093d55784382e547b