### PR TITLE
Improve gradio UI with persistent queues

### DIFF
--- a/src/chatterbox/__init__.py
+++ b/src/chatterbox/__init__.py
@@ -6,8 +6,12 @@ except ImportError:
 __version__ = version("chatterbox-tts")
 
 
-from .tts import ChatterboxTTS
-from .vc import ChatterboxVC
+try:
+    from .tts import ChatterboxTTS
+    from .vc import ChatterboxVC
+except Exception:  # optional when dependencies missing
+    ChatterboxTTS = None
+    ChatterboxVC = None
 from .audio_editing import (
     splice_audios,
     trim_audio,


### PR DESCRIPTION
## Summary
- store samples and outputs using localStorage
- number queue entries
- add generate-all, keep-generating and clear-storage controls
- avoid hard dependency on torch when importing package

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538d9744208330861621531b320627