### PR TITLE
Add webapp helper for Flask

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,22 @@
+"""Entrypoint for running the Flask web server.
+
+This module exposes a ``webapp`` function which returns the Flask ``app``
+instance. Having a callable named ``webapp`` is useful when deploying the
+project on platforms that expect a factory function (e.g. gunicorn or certain
+cloud providers).  The script can still be executed directly for local
+development.
+"""
+
 from flask_app import create_app
 
 app = create_app()
+
+
+def webapp():
+    """Return the Flask application instance."""
+
+    return app
+
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- expose a `webapp()` function so WSGI servers can load the Flask app

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545b78d9388330b3d97be45868008f