### PR TITLE
Add Flask index route and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ with open("sample_prompts.json") as f:
 wav = model.generate(sample_prompts[0])
 ```
 
+## Running the Flask API
+
+You can also interact with Chatterbox via a lightweight REST API. Start the
+server by running:
+
+```bash
+python main.py
+```
+
+This launches a Flask application on `http://localhost:5000`. The root endpoint
+returns a short message and you can access the TTS and voice conversion APIs at
+`/api/tts` and `/api/vc` respectively.
+
 # Supported Lanugage
 Currenlty only English.
 

--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, jsonify
 from .routes.tts import tts_bp
 from .routes.vc import vc_bp
 from .routes.editing import editing_bp
@@ -9,4 +9,11 @@ def create_app() -> Flask:
     app.register_blueprint(tts_bp, url_prefix="/api")
     app.register_blueprint(vc_bp, url_prefix="/api")
     app.register_blueprint(editing_bp, url_prefix="/api/edit")
+
+    @app.get("/")
+    def index():
+        """Simple landing page for the API."""
+
+        return jsonify({"message": "Chatterbox API", "endpoints": ["/api/tts", "/api/vc", "/api/edit"]})
+
     return app

--- a/main.py
+++ b/main.py
@@ -1,6 +1,22 @@
+"""Entrypoint for running the Flask web server.
+
+This module exposes a ``webapp`` function which returns the Flask ``app``
+instance. Having a callable named ``webapp`` is useful when deploying the
+project on platforms that expect a factory function (e.g. gunicorn or certain
+cloud providers).  The script can still be executed directly for local
+development.
+"""
+
 from flask_app import create_app
 
 app = create_app()
+
+
+def webapp():
+    """Return the Flask application instance."""
+
+    return app
+
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- add an index route so hitting `/` doesn't return a 404
- document how to run the Flask API

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68545b78d9388330b3d97be45868008f