### PR TITLE
Add themed landing page

### DIFF
--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template
 from .routes.tts import tts_bp
 from .routes.vc import vc_bp
 from .routes.editing import editing_bp
@@ -12,7 +12,13 @@ def create_app() -> Flask:
 
     @app.get("/")
     def index():
-        """Simple landing page for the API."""
+        """Render a simple landing page."""
+
+        return render_template("index.html")
+
+    @app.get("/api")
+    def api_root():
+        """Return basic API information."""
 
         return jsonify({"message": "Chatterbox API", "endpoints": ["/api/tts", "/api/vc", "/api/edit"]})
 

--- a/flask_app/static/css/style.css
+++ b/flask_app/static/css/style.css
@@ -1,0 +1,67 @@
+:root {
+    --background: #21252d;
+    --mathblue: #1b91d6;
+    --sky: #8ecae6;
+    --slatecard: #1a1e2a;
+    --lightblue: #bfdbfe;
+    --hoverblue: #60a5fa;
+    --slategray: #1a1e2a;
+    --softgray: #9ca3af;
+}
+
+.theme-conquestace {
+    --background: #21252d;
+    --mathblue: #1b91d6;
+    --sky: #8ecae6;
+    --slatecard: #1a1e2a;
+    --lightblue: #bfdbfe;
+    --hoverblue: #60a5fa;
+    --slategray: #1a1e2a;
+    --softgray: #9ca3af;
+}
+
+.theme-conquestace-light {
+    --background: #f9fafb;
+    --mathblue: #1b4d91;
+    --sky: #297fb8;
+    --slatecard: #f3f4f6;
+    --lightblue: #dbeafe;
+    --hoverblue: #60a5fa;
+    --slategray: #6b7280;
+    --softgray: #9ca3af;
+}
+
+body {
+    background-color: var(--background);
+    color: var(--softgray);
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 1rem;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+button {
+    background-color: var(--mathblue);
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: var(--hoverblue);
+}
+
+a {
+    color: var(--lightblue);
+}
+
+a:hover {
+    color: var(--hoverblue);
+}

--- a/flask_app/static/js/theme.js
+++ b/flask_app/static/js/theme.js
@@ -1,0 +1,14 @@
+function setTheme(theme) {
+    document.documentElement.className = theme;
+    localStorage.setItem('theme', theme);
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const saved = localStorage.getItem('theme') || 'theme-conquestace';
+    setTheme(saved);
+    document.getElementById('toggle-theme').addEventListener('click', function () {
+        const current = document.documentElement.className;
+        const next = current === 'theme-conquestace' ? 'theme-conquestace-light' : 'theme-conquestace';
+        setTheme(next);
+    });
+});

--- a/flask_app/templates/base.html
+++ b/flask_app/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" class="theme-conquestace">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title if title else 'Chatterbox' }}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <header>
+        <h1>Chatterbox API</h1>
+        <button id="toggle-theme">Toggle Theme</button>
+    </header>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+    <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
+</body>
+</html>

--- a/flask_app/templates/index.html
+++ b/flask_app/templates/index.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<p>Welcome to Chatterbox. Use the API endpoints below:</p>
+<ul>
+    <li><a href="/api/tts">/api/tts</a> - Text to speech</li>
+    <li><a href="/api/vc">/api/vc</a> - Voice conversion</li>
+    <li><a href="/api/edit">/api/edit</a> - Audio editing</li>
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend the Flask app with a simple HTML landing page
- provide dark and light "conquestace" themes
- add CSS and JS for switching themes
- expose former JSON info at `/api`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854601fddc8833092071346a96e128f