### PR TITLE
Improve Flask web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,14 @@ wav = model.generate(sample_prompts[0])
 
 ## Running the Flask API
 
-You can also interact with Chatterbox via a lightweight REST API. Start the
-server by running:
+You can also interact with Chatterbox via a lightweight REST API. First install
+the optional server dependencies:
+
+```bash
+pip install -e .[server]
+```
+
+Then start the server by running:
 
 ```bash
 python main.py

--- a/flask_app/models.py
+++ b/flask_app/models.py
@@ -1,6 +1,11 @@
-import torch
-from chatterbox.tts import ChatterboxTTS
-from chatterbox.vc import ChatterboxVC
+try:
+    import torch
+    from chatterbox.tts import ChatterboxTTS
+    from chatterbox.vc import ChatterboxVC
+except ModuleNotFoundError as e:  # pragma: no cover - torch heavy
+    raise ImportError(
+        "Required dependencies for Chatterbox are not installed."
+    ) from e
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/flask_app/routes/tts.py
+++ b/flask_app/routes/tts.py
@@ -2,7 +2,10 @@ from flask import Blueprint, request, send_file, jsonify
 import io
 import soundfile as sf
 
-from ..models import get_tts_model
+try:
+    from ..models import get_tts_model
+except ImportError:  # pragma: no cover - heavy deps
+    get_tts_model = None
 from ..utils import set_seed
 
 
@@ -24,6 +27,9 @@ def tts():
 
     if seed_num:
         set_seed(seed_num)
+
+    if get_tts_model is None:
+        return {"error": "TTS dependencies not installed"}, 500
 
     model = get_tts_model()
     wav = model.generate(

--- a/flask_app/routes/vc.py
+++ b/flask_app/routes/vc.py
@@ -3,7 +3,10 @@ import tempfile
 import soundfile as sf
 from flask import Blueprint, request, send_file
 
-from ..models import get_vc_model
+try:
+    from ..models import get_vc_model
+except ImportError:  # pragma: no cover - heavy deps
+    get_vc_model = None
 
 
 vc_bp = Blueprint("vc", __name__)
@@ -13,6 +16,9 @@ vc_bp = Blueprint("vc", __name__)
 def voice_convert():
     if "audio" not in request.files:
         return {"error": "audio file required"}, 400
+
+    if get_vc_model is None:
+        return {"error": "VC dependencies not installed"}, 500
 
     audio_file = request.files["audio"]
     target_file = request.files.get("target_voice")

--- a/flask_app/templates/index.html
+++ b/flask_app/templates/index.html
@@ -6,4 +6,34 @@
     <li><a href="/api/vc">/api/vc</a> - Voice conversion</li>
     <li><a href="/api/edit">/api/edit</a> - Audio editing</li>
 </ul>
+
+<h2>Quick Demo</h2>
+<form id="tts-form">
+    <label for="tts-text">Text:</label><br>
+    <textarea id="tts-text" name="text" rows="4" cols="50"></textarea><br>
+    <button type="submit">Synthesize</button>
+</form>
+<audio id="tts-audio" controls style="display:none"></audio>
+
+<script>
+document.getElementById('tts-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const text = document.getElementById('tts-text').value;
+    const resp = await fetch('/api/tts', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({text})
+    });
+    if (resp.ok) {
+        const blob = await resp.blob();
+        const url = URL.createObjectURL(blob);
+        const audio = document.getElementById('tts-audio');
+        audio.src = url;
+        audio.style.display = 'block';
+        audio.play();
+    } else {
+        alert('Error synthesizing speech');
+    }
+});
+</script>
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "soundfile>=0.13"
 ]
 
+[project.optional-dependencies]
+server = [
+    "Flask>=3.1",
+]
+
 [project.urls]
 Homepage = "https://github.com/resemble-ai/chatterbox"
 Repository = "https://github.com/resemble-ai/chatterbox"


### PR DESCRIPTION
## Summary
- add `server` extra to `pyproject.toml` for Flask
- document installing optional server requirements in README
- provide a basic web demo on the index page
- make lazy imports resilient when heavy deps are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685461ddaa6c8330bc79f11a02e10d2f