### PR TITLE
Add Gradio demo to Flask server

### DIFF
--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -3,12 +3,22 @@ from .routes.tts import tts_bp
 from .routes.vc import vc_bp
 from .routes.editing import editing_bp
 
+try:  # Optional Gradio integration
+    from gradio import mount_gradio_app
+    from main_gradio import demo as gradio_demo
+except Exception:  # pragma: no cover - gradio optional
+    mount_gradio_app = None
+    gradio_demo = None
+
 
 def create_app() -> Flask:
     app = Flask(__name__)
     app.register_blueprint(tts_bp, url_prefix="/api")
     app.register_blueprint(vc_bp, url_prefix="/api")
     app.register_blueprint(editing_bp, url_prefix="/api/edit")
+
+    if mount_gradio_app and gradio_demo:  # pragma: no cover - optional
+        mount_gradio_app(app, gradio_demo, path="/gradio")
 
     @app.get("/")
     def index():

--- a/flask_app/templates/index.html
+++ b/flask_app/templates/index.html
@@ -5,6 +5,7 @@
     <li><a href="/api/tts">/api/tts</a> - Text to speech</li>
     <li><a href="/api/vc">/api/vc</a> - Voice conversion</li>
     <li><a href="/api/edit">/api/edit</a> - Audio editing</li>
+    <li><a href="/gradio">/gradio</a> - Full demo interface</li>
 </ul>
 
 <h2>Quick Demo</h2>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 [project.optional-dependencies]
 server = [
     "Flask>=3.1",
+    "gradio>=4.28.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- mount `main_gradio` Blocks on `/gradio` in the Flask app
- link to the new demo interface from `index.html`
- include Gradio in optional server dependencies

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546e76aff883309840cbfd80642e95