### PR TITLE
Fix Gradio mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,10 @@ Then start the server by running:
 python main.py
 ```
 
-This launches a Flask application on `http://localhost:5000`. The root endpoint
-returns a short message and you can access the TTS and voice conversion APIs at
+This launches a Flask application on `http://localhost:5000`. If Gradio is also
+installed, the server will automatically run via `uvicorn` and expose the full
+demo UI at `/gradio` in addition to the REST API. The root endpoint returns a
+short message and you can access the TTS and voice conversion APIs at
 `/api/tts` and `/api/vc` respectively.
 
 # Supported Lanugage

--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -3,6 +3,10 @@ from .routes.tts import tts_bp
 from .routes.vc import vc_bp
 from .routes.editing import editing_bp
 
+# Optional imports for mounting the Gradio demo. The gradio demo is an ASGI
+# application, so if it's available we later wrap the Flask app with FastAPI
+# and Starlette's WSGIMiddleware to serve everything from a single ASGI app.
+
 try:  # Optional Gradio integration
     from gradio import mount_gradio_app
     from main_gradio import demo as gradio_demo
@@ -11,25 +15,45 @@ except Exception:  # pragma: no cover - gradio optional
     gradio_demo = None
 
 
-def create_app() -> Flask:
-    app = Flask(__name__)
-    app.register_blueprint(tts_bp, url_prefix="/api")
-    app.register_blueprint(vc_bp, url_prefix="/api")
-    app.register_blueprint(editing_bp, url_prefix="/api/edit")
+def create_app():
+    """Create and return the web application.
 
-    if mount_gradio_app and gradio_demo:  # pragma: no cover - optional
-        mount_gradio_app(app, gradio_demo, path="/gradio")
+    If the optional Gradio dependencies are installed, this function returns a
+    FastAPI application that serves both the Flask routes and the Gradio demo.
+    Otherwise, a plain Flask application is returned.
+    """
 
-    @app.get("/")
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(tts_bp, url_prefix="/api")
+    flask_app.register_blueprint(vc_bp, url_prefix="/api")
+    flask_app.register_blueprint(editing_bp, url_prefix="/api/edit")
+
+    @flask_app.get("/")
     def index():
         """Render a simple landing page."""
 
         return render_template("index.html")
 
-    @app.get("/api")
+    @flask_app.get("/api")
     def api_root():
         """Return basic API information."""
 
-        return jsonify({"message": "Chatterbox API", "endpoints": ["/api/tts", "/api/vc", "/api/edit"]})
+        return jsonify(
+            {"message": "Chatterbox API", "endpoints": ["/api/tts", "/api/vc", "/api/edit"]}
+        )
 
-    return app
+    # If gradio is installed, wrap the Flask app with FastAPI so we can mount the
+    # gradio demo under the /gradio endpoint. Otherwise just return the Flask app
+    # directly.
+    if mount_gradio_app and gradio_demo:  # pragma: no cover - optional
+        from fastapi import FastAPI
+        from starlette.middleware.wsgi import WSGIMiddleware
+
+        fastapi_app = FastAPI()
+        # Mount the Flask application at the root.
+        fastapi_app.mount("/", WSGIMiddleware(flask_app))
+        # Mount the gradio demo at /gradio.
+        mount_gradio_app(fastapi_app, gradio_demo, path="/gradio")
+        return fastapi_app
+
+    return flask_app

--- a/main.py
+++ b/main.py
@@ -9,6 +9,12 @@ development.
 
 from flask_app import create_app
 
+try:
+    import uvicorn  # type: ignore
+except Exception:  # pragma: no cover - uvicorn optional
+    uvicorn = None
+
+
 app = create_app()
 
 
@@ -19,4 +25,10 @@ def webapp():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    # If the application object has a ``router`` attribute we are dealing with a
+    # FastAPI/Starlette app (used when Gradio is enabled). In that case run with
+    # ``uvicorn``. Otherwise fall back to Flask's built-in development server.
+    if hasattr(app, "router") and uvicorn is not None:
+        uvicorn.run(app, host="0.0.0.0", port=5000)
+    else:
+        app.run(debug=True)


### PR DESCRIPTION
## Summary
- mount Flask app using WSGIMiddleware so gradio can live under `/gradio`
- start uvicorn when fastapi is used
- clarify docs about gradio route

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854982ed2b083309342c639f549f56c